### PR TITLE
Fix: filter draft posts from RSS feed and search index

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,7 +3,7 @@ import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
 
 export const GET: APIRoute = async (context) => {
-    const blog = await getCollection("blog");
+    const blog = await getCollection("blog", ({ data }) => !data.draft);
 
     return rss({
         // `<title>` field in output xml

--- a/src/pages/search-core.json.ts
+++ b/src/pages/search-core.json.ts
@@ -20,7 +20,7 @@ export const GET: APIRoute = async (context) => {
         articles: []
     };
 
-    const blog = await getCollection("blog");
+    const blog = await getCollection("blog", ({ data }) => !data.draft);
     let maxSize = 0;
     for (const post of blog) {
         const title = post.data.title;


### PR DESCRIPTION
## Summary
- Filter draft posts from the RSS feed (`rss.xml.ts`) and search index (`search-core.json.ts`)
- Adds the same `({ data }) => !data.draft` filter already used on all other public-facing pages

Closes #28