### PR TITLE
Fix: correct OG image meta tag typos

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -119,9 +119,9 @@ import KeyBoardKey from "~components/KeyBoardKey";
                                 : new URL(ogImgSrc.src, Astro.site)
                         }
                     />
-                    <meta property="og:image:width" content={"1200px"} />
-                    <meta property="og:image:height" content={"600px"} />
-                    <meta property="og:image:type" content="image/png." />
+                    <meta property="og:image:width" content={"1200"} />
+                    <meta property="og:image:height" content={"600"} />
+                    <meta property="og:image:type" content="image/png" />
                 </>
             )
         }


### PR DESCRIPTION
## Summary
- Remove trailing period from `og:image:type` (`"image/png."` -> `"image/png"`)
- Remove `px` units from `og:image:width` and `og:image:height` (`"1200px"` -> `"1200"`, `"600px"` -> `"600"`) per the OpenGraph specification which expects plain numbers

Closes #29