### PR TITLE
Fix: use explicit date sort instead of fragile .reverse()

### DIFF
--- a/src/pages/blog/tags/[tag]/index.astro
+++ b/src/pages/blog/tags/[tag]/index.astro
@@ -23,7 +23,9 @@ const thisTag = await getEntry("tag", tag);
 
 const allBlogPosts = await getCollection("blog", ({ data }) => {
     return !data.draft && data.tags.some((articleTag) => articleTag.slug === tag);
-}).then((recordSet) => recordSet.reverse());
+}).then((recordSet) =>
+    recordSet.sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+);
 
 const { Content } = await thisTag.render();
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,9 @@ const allBlogPosts = await getCollection("blog", ({ data }) => {
     return !data.draft;
 });
 
-const recentBlogPosts = allBlogPosts.reverse().slice(0, 5);
+const recentBlogPosts = allBlogPosts
+    .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+    .slice(0, 5);
 const homepageData = await getEntry("page", "homepage");
 const { Content } = await homepageData.render();
 ---


### PR DESCRIPTION
## Summary
- Replace `.reverse()` with `.sort()` using date comparison on the homepage and tag detail pages
- The Astro `glob` loader does not guarantee chronological file ordering, so `.reverse()` could produce incorrect post order depending on the environment
- This matches the explicit sort pattern already used in `src/pages/blog/index.astro`

### Files changed
- `src/pages/index.astro` - homepage recent posts
- `src/pages/blog/tags/[tag]/index.astro` - posts filtered by tag

Closes #30