### PR TITLE
Fix: use dynamic og:type based on page type

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,6 +20,7 @@ interface Props {
     };
     className?: string;
     publishDate?: string;
+    ogType?: "website" | "article";
 }
 
 const navItems: Array<{ name: string; href: string; className?: string; icon?: IconName }> = [
@@ -53,7 +54,8 @@ const {
     sideWidth = "full",
     headerImage,
     className = "",
-    publishDate
+    publishDate,
+    ogType = "website"
 } = Astro.props;
 
 const siteTitle = "Christopher Vachon";
@@ -89,14 +91,14 @@ import KeyBoardKey from "~components/KeyBoardKey";
         <meta name="format-detection" content="telephone=no" />
         <meta name="msapplication-config" content="/browserconfig.xml" />
         <meta property="og:site_name" content="All About Christopher Vachon" />
-        <meta property="og:type" content="article" />
+        <meta property="og:type" content={ogType} />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={descriptionTemplate} />
         <meta property="og:url" content={canonical} />
         <meta property="og:author" content={ogAuthor} />
-        {publishDate && <meta property="article:published_time" content={publishDate} />}
-        {publishDate && <meta property="article:modified_time" content={publishDate} />}
-        <meta property="article:publisher" content="https://github.com/CodeVachon" />
+        {ogType === "article" && publishDate && <meta property="article:published_time" content={publishDate} />}
+        {ogType === "article" && publishDate && <meta property="article:modified_time" content={publishDate} />}
+        {ogType === "article" && <meta property="article:publisher" content="https://github.com/CodeVachon" />}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={descriptionTemplate} />

--- a/src/pages/blog/[slug]/index.astro
+++ b/src/pages/blog/[slug]/index.astro
@@ -66,6 +66,7 @@ const tags = await getEntries(entry.data.tags);
     sideWidth="half"
     headerImage={entry.data.image}
     publishDate={dayjs(entry.data.date).toISOString()}
+    ogType="article"
 >
     <article class="flex flex-col gap-8 lg:max-w-[750px]">
         <header class="border-b">


### PR DESCRIPTION
## Summary
- Add `ogType` prop to Layout component, defaulting to `"website"`
- Blog post pages now pass `ogType="article"` explicitly
- `article:published_time`, `article:modified_time`, and `article:publisher` meta tags are now only rendered when `ogType === "article"`
- All other pages (homepage, tags, code, etc.) correctly use `og:type: website`

Closes #31