### PR TITLE
Fix: remove maximum-scale=1 to allow pinch-to-zoom (accessibility)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -74,7 +74,7 @@ import KeyBoardKey from "~components/KeyBoardKey";
 <html lang="en" class="dark h-full antialiased" style="color-scheme: dark;">
     <head>
         <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href={`${Astro.site}me-300.png`} type="image/png" />
         <title>{titleTemplate}</title>
         <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
## Summary
- Remove `maximum-scale=1` from the viewport meta tag to allow pinch-to-zoom on mobile devices
- This is an accessibility improvement per WCAG 1.4.4 (Resize Text) -- users with low vision rely on pinch-to-zoom
- Both Google Lighthouse and axe-core flag `maximum-scale=1` as an accessibility violation

Closes #32