### PR TITLE
Perf: use client:idle for KeyBoardKey component

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -185,7 +185,7 @@ import KeyBoardKey from "~components/KeyBoardKey";
                         }
                         <li class="hidden pt-6 lg:block">
                             <p class="text-xs text-slate-500">
-                                <KeyBoardKey keyModifier="cmd" client:load>K</KeyBoardKey> to open Command
+                                <KeyBoardKey keyModifier="cmd" client:idle>K</KeyBoardKey> to open Command
                                 Pallet
                             </p>
                         </li>


### PR DESCRIPTION
## Summary
- Change `<KeyBoardKey>` from `client:load` to `client:idle` in the Layout sidebar
- This component only reads `navigator.platform` to display the correct modifier key symbol -- it doesn't need immediate hydration
- Reduces initial JavaScript execution on page load

Note: `<Search>` already uses `client:visible` on main, and `TOCPanel` does not exist on main, so only `KeyBoardKey` needed updating.

Closes #33