### PR TITLE
Fix: correct sitemap path in robots.txt

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -7,5 +7,5 @@ export const GET: APIRoute = async (context) => {
 const content = (site: URL) => `
 User-agent: *
 Allow: /
-Sitemap: ${site.origin}/sitemap.xml
+Sitemap: ${site.origin}/sitemap-index.xml
 `;


### PR DESCRIPTION
## Summary
- Change sitemap reference from `/sitemap.xml` to `/sitemap-index.xml` in `robots.txt`
- `@astrojs/sitemap` generates `/sitemap-index.xml` by default, so the previous path would 404 for search engine crawlers

Closes #34