### PR TITLE
Chore: clean up unused and misplaced dependencies

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,6 @@ import a11yEmoji from "@fec/remark-a11y-emoji";
 import { remarkReadingTime } from "./src/lib/readingTime";
 import sitemap from "@astrojs/sitemap";
 import metaTags from "astro-meta-tags";
-import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
 
 const runningPort = 4006;
 
@@ -25,23 +24,6 @@ export default defineConfig({
     redirects: {
         "/old-page": "/new-page"
     },
-    // Required to Add Buffer Polyfill to the Browser for Bloom Filters
-    // vite: {
-    //     optimizeDeps: {
-    //         esbuildOptions: {
-    //             // Node.js global to browser globalThis
-    //             define: {
-    //                 global: "globalThis"
-    //             },
-    //             // Enable esbuild polyfill plugins
-    //             plugins: [
-    //                 NodeGlobalsPolyfillPlugin({
-    //                     buffer: true
-    //                 })
-    //             ]
-    //         }
-    //     }
-    // },
     integrations: [
         sitemap(),
         react(),

--- a/package.json
+++ b/package.json
@@ -11,27 +11,16 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/check": "^0.7.0",
     "@astrojs/react": "3.6.0",
     "@astrojs/rss": "4.0.7",
     "@astrojs/sitemap": "3.1.6",
     "@astrojs/tailwind": "^5.1.0",
-    "@astrojs/ts-plugin": "^1.8.0",
     "@codevachon/classnames": "^1.3.0",
-    "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@fec/remark-a11y-emoji": "^4.0.2",
     "@tailwindcss/typography": "^0.5.13",
-    "@types/figlet": "^1.5.8",
-    "@types/inquirer": "^9.0.7",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "@types/tryghost__content-api": "^1.3.16",
-    "@types/turndown": "^5.0.4",
     "@vercel/og": "^0.6.2",
     "astro": "4.11.3",
-    "astro-capo": "^0.0.1",
     "astro-meta-tags": "^0.3.0",
-    "bloom-filters": "^3.0.1",
     "dayjs": "^1.11.11",
     "figlet": "^1.7.0",
     "graphql": "^16.8.1",
@@ -42,21 +31,26 @@
     "react-dom": "^18.3.1",
     "reading-time": "^1.5.0",
     "remark-toc": "^9.0.0",
-    "tailwindcss": "^3.4.4",
-    "typescript": "^5.4.5"
+    "tailwindcss": "^3.4.4"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.7.0",
+    "@astrojs/ts-plugin": "^1.8.0",
     "@tryghost/content-api": "^1.11.21",
     "@types/bun": "^1.1.3",
+    "@types/figlet": "^1.5.8",
+    "@types/inquirer": "^9.0.7",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@types/tryghost__content-api": "^1.3.16",
+    "@types/turndown": "^5.0.4",
     "prettier": "^3.3.1",
     "prettier-plugin-astro": "^0.13.0",
     "prettier-plugin-tailwindcss": "^0.5.14",
-    "turndown": "^7.2.0"
+    "turndown": "^7.2.0",
+    "typescript": "^5.4.5"
   },
   "module": "index.ts",
-  "peerDependencies": {
-    "typescript": "^5.0.0"
-  },
   "engines": {
     "node": "^18.19.1",
     "npm": "^10.2.4"


### PR DESCRIPTION
## Summary
- **Removed unused packages:** `astro-capo` (not in integrations), `@esbuild-plugins/node-globals-polyfill` (only used in commented-out code), `bloom-filters` (commented out in search-core)
- **Moved dev-only packages to `devDependencies`:** `@astrojs/check`, `@astrojs/ts-plugin`, all `@types/*` packages, `typescript`
- **Removed `peerDependencies`** for typescript (not needed for an application project)
- **Removed dead commented-out polyfill code** from `astro.config.mjs`

Closes #35