### PR TITLE
Fix: add Props interface and remove dead code in Glow.astro

### DIFF
--- a/src/components/Glow.astro
+++ b/src/components/Glow.astro
@@ -1,7 +1,9 @@
 ---
-const { className } = Astro.props;
+interface Props {
+    className?: string;
+}
 
-const highlightColor = "rgba(256, 89, 248, 0.4)";
+const { className } = Astro.props;
 ---
 
 <!-- GLOW START -->


### PR DESCRIPTION
## Summary
- Add missing `interface Props` for the `className` prop, matching the pattern used in every other component
- Remove unused `highlightColor` variable which also contained an invalid RGB value (`256`, max is `255`)

Closes #36