### PR TITLE
Fix: replace 'as any' with 'as ImageMetadata' for image props

### DIFF
--- a/src/components/ArticleList.astro
+++ b/src/components/ArticleList.astro
@@ -1,5 +1,5 @@
 ---
-import { Picture } from "astro:assets";
+import { Picture, type ImageMetadata } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 interface Props {
     articles: Array<CollectionEntry<"blog">>;
@@ -20,7 +20,7 @@ const { articles = [], grid = false } = Astro.props;
                     <figure class="w-full flex-shrink-0 overflow-hidden md:mr-6 md:w-64 lg:w-full">
                         <Picture
                             inferSize={true}
-                            src={post.data.image as any}
+                            src={post.data.image as ImageMetadata}
                             class="rounded-md object-cover md:aspect-video lg:aspect-auto lg:rounded-none"
                             alt={post.data.title}
                             formats={["webp", "jpeg"]}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import { Picture, getImage } from "astro:assets";
+import { Picture, getImage, type ImageMetadata } from "astro:assets";
 import { Icon, HamburgerIcon, CloseIcon } from "~components/Icons";
 import type { IconName } from "~components/Icons";
 import myImage from "../assets/me.png";
@@ -231,7 +231,7 @@ import KeyBoardKey from "~components/KeyBoardKey";
                         <figure class="-mx-6 -mt-6 mb-6 max-w-[1200px] overflow-hidden lg:-mt-24">
                             <Picture
                                 inferSize={true}
-                                src={headerImage as any}
+                                src={headerImage as ImageMetadata}
                                 class="w-full object-cover md:aspect-video"
                                 alt={titleTemplate}
                                 widths={[320, 640, 1280, 1920]}


### PR DESCRIPTION
## Summary
- Replace `as any` type casts with `as ImageMetadata` in `Layout.astro` and `ArticleList.astro`
- Import `ImageMetadata` type from `astro:assets`
- Preserves type safety while resolving the mismatch between content collection image types and `Picture` component's `src` prop when `inferSize` is used

Closes #37