### PR TITLE
Fix: eliminate flash of wrong theme on page load

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -74,6 +74,19 @@ import KeyBoardKey from "~components/KeyBoardKey";
 <html lang="en" class="dark h-full antialiased" style="color-scheme: dark;">
     <head>
         <meta charset="utf-8" />
+        <script is:inline>
+            (function () {
+                const theme = localStorage.getItem("theme");
+                const color = localStorage.getItem("theme-color");
+                if (theme === "light") {
+                    document.documentElement.classList.remove("dark");
+                    document.documentElement.style.colorScheme = "light";
+                }
+                if (color) {
+                    document.documentElement.setAttribute("data-theme", color);
+                }
+            })();
+        </script>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         <link rel="icon" href={`${Astro.site}me-300.png`} type="image/png" />
         <title>{titleTemplate}</title>


### PR DESCRIPTION
## Summary
- Add an inline `<script>` in `<head>` (before any rendering) that synchronously reads theme preferences from `localStorage` and applies them
- This prevents the flash of default dark/cool-cyber theme when users have selected a different color theme or light mode
- The existing `themeSetup` on `astro:page-load` in ThemeToggle continues to handle View Transition navigations

### How it works
The script runs before the browser paints and:
1. Reads `"theme"` from localStorage -- if `"light"`, removes `dark` class and updates `color-scheme`
2. Reads `"theme-color"` from localStorage -- applies the `data-theme` attribute

Closes #38