### PR TITLE
Feat: add JSON-LD structured data for blog posts and website

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -132,6 +132,38 @@ import KeyBoardKey from "~components/KeyBoardKey";
             title={siteTitle}
             href={`${Astro.site}rss.xml`}
         />
+        {publishDate ? (
+            <script type="application/ld+json" set:html={JSON.stringify({
+                "@context": "https://schema.org",
+                "@type": "BlogPosting",
+                "headline": title,
+                "description": descriptionTemplate,
+                "datePublished": publishDate,
+                "dateModified": publishDate,
+                "author": {
+                    "@type": "Person",
+                    "name": ogAuthor,
+                    "url": String(Astro.site)
+                },
+                "publisher": {
+                    "@type": "Person",
+                    "name": ogAuthor
+                },
+                "mainEntityOfPage": {
+                    "@type": "WebPage",
+                    "@id": String(canonical)
+                },
+                ...(cardImage ? { "image": String(new URL(ogImgSrc.src, Astro.site)) } : {})
+            })} />
+        ) : (
+            <script type="application/ld+json" set:html={JSON.stringify({
+                "@context": "https://schema.org",
+                "@type": "WebSite",
+                "name": siteTitle,
+                "description": descriptionTemplate,
+                "url": String(Astro.site)
+            })} />
+        )}
         <ViewTransitions />
     </head>
     <body


### PR DESCRIPTION
## Summary
- Add `<script type="application/ld+json">` structured data to the Layout `<head>`
- Blog posts (pages with `publishDate`) get `BlogPosting` schema with headline, description, author, dates, and image
- All other pages get `WebSite` schema with name, description, and URL
- Enables rich results in Google Search and improves SEO

### Validation
After deployment, use [Google's Rich Results Test](https://search.google.com/test/rich-results) to validate the markup.

Closes #40