### PR TITLE
Chore: remove placeholder redirect from astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,9 +22,6 @@ export default defineConfig({
     },
     site: url,
     prefetch: true,
-    redirects: {
-        "/old-page": "/new-page"
-    },
     // Required to Add Buffer Polyfill to the Browser for Bloom Filters
     // vite: {
     //     optimizeDeps: {


### PR DESCRIPTION
## Summary
- Remove the `/old-page` -> `/new-page` redirect from `astro.config.mjs`
- This was a template/example entry that doesn't correspond to any actual routes

Closes #41