### PR TITLE
Chore: standardize image format naming to 'jpg' across components

### DIFF
--- a/src/components/ArticleList.astro
+++ b/src/components/ArticleList.astro
@@ -23,8 +23,8 @@ const { articles = [], grid = false } = Astro.props;
                             src={post.data.image as any}
                             class="rounded-md object-cover md:aspect-video lg:aspect-auto lg:rounded-none"
                             alt={post.data.title}
-                            formats={["webp", "jpeg"]}
-                            fallbackFormat="jpeg"
+                            formats={["webp", "jpg"]}
+                            fallbackFormat="jpg"
                             widths={[320, 640, 1280, 1920]}
                         />
                     </figure>


### PR DESCRIPTION
## Summary
- Change `ArticleList.astro` from `"jpeg"` to `"jpg"` for both `formats` and `fallbackFormat`
- Matches the `"jpg"` convention used in Layout, Sidebar, and ProfileHero components
- Both values produce identical output, this is purely a consistency improvement

Closes #42