### PR TITLE
Fix: add null safety for post.body in search index generator

### DIFF
--- a/src/pages/search-core.json.ts
+++ b/src/pages/search-core.json.ts
@@ -31,7 +31,7 @@ export const GET: APIRoute = async (context) => {
         const link = `/blog/${post.slug}/`;
 
         const uniqueWords = new Set<string>();
-        for (const word of post.body.split(new RegExp("[\\s]{1,}", "g"))) {
+        for (const word of (post.body ?? "").split(new RegExp("[\\s]{1,}", "g"))) {
             const cleanedWords = word
                 .replace(/[^a-zA-Z0-9]/g, " ")
                 .trim()


### PR DESCRIPTION
## Summary
- Add nullish coalescing (`post.body ?? ""`) in `search-core.json.ts` to prevent a runtime error if a blog post has only frontmatter and no body content
- In Astro 5 with the glob loader, `body` can be `undefined` for content files with empty bodies

Closes #43